### PR TITLE
Updating dependencies for benchmark

### DIFF
--- a/Spock-scotty-benchmark.cabal
+++ b/Spock-scotty-benchmark.cabal
@@ -12,9 +12,9 @@ cabal-version:       >=1.10
 
 executable Spock-scotty-benchmark
   main-is:             Main.hs
-  build-depends:       base >=4.6 && <4.7,
-                       Spock ==0.5.1.0,
-                       scotty ==0.6.*
+  build-depends:       base >=4.7 && <4.8,
+                       Spock ==0.7.10.0,
+                       scotty ==0.9.*
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O3 -threaded

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,7 +4,7 @@ module Main where
 import System.Environment
 
 import qualified Web.Scotty as Scotty
-import qualified Web.Spock as Spock
+import qualified Web.Spock.Simple as Spock
 
 main =
     do args <- getArgs
@@ -21,7 +21,7 @@ main =
                   do p <- Scotty.param "1"
                      Scotty.text p
          ["spock"] ->
-             Spock.spockT port id $
+             Spock.runSpock port $ Spock.spockT id $
              do Spock.get "/echo/hello-world" $
                   Spock.text "Hello World"
                 Spock.get "/echo/plain/:param" $


### PR DESCRIPTION
Technically it is now encouraged to use the typesafe routing in Spock, but I've used the Web.Spock.Simple routing to keep as much of the code the same as before.
